### PR TITLE
typo and paths fix

### DIFF
--- a/UE4Parse/Assets/PackageReader.py
+++ b/UE4Parse/Assets/PackageReader.py
@@ -85,6 +85,7 @@ class LegacyPackageReader(Package):
     # @profile
     def __init__(self, uasset: BinaryStream, uexp: BinaryStream = None, ubulk: BinaryStream = None,
                  provider: "DefaultFileProvider" = None, load_mode: EPackageLoadMode = EPackageLoadMode.Full) -> None:
+        FAssetReader.provider = provider
         self.reader = FAssetReader(uasset.base_stream, self, size=uasset.size)
         self.reader.mappings = uasset.mappings
         self.reader.set_ar_version(provider.Versions.UEVersion)

--- a/UE4Parse/Assets/UObject/UStruct.py
+++ b/UE4Parse/Assets/UObject/UStruct.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Union, TYPE_CHECKING, Callable, Any
+from typing import Tuple, Union, Dict, TYPE_CHECKING, Callable, Any
 
 from UE4Parse.Assets.Objects.FPackageIndex import FPackageIndex
 from UE4Parse.Assets.UObject.UField import UField
@@ -51,7 +51,7 @@ class UStruct(UField):
 
         self.ChildProperties = tuple(children)
 
-    def GetValue(self) -> dict[str, Any]:
+    def GetValue(self) -> Dict[str, Any]:
         props = super().GetValue()
         props["SuperStruct"] = self.SuperStruct.GetValue()
         props["Children"] = [child.GetValue() for child in self.Children]

--- a/UE4Parse/Provider/Vfs/AbstractVfsFileProvider.py
+++ b/UE4Parse/Provider/Vfs/AbstractVfsFileProvider.py
@@ -96,7 +96,7 @@ class AbstractVfsFileProvider(ABC):
                 files.append(x)
         return files
 
-    def submit_key(self, guid: Union[str, FGuid], key: Optional[FAESKey]) -> int:
+    def submit_key(self, guid: Union[str, FGuid]=FGuid(0,0,0,0), key: Optional[FAESKey]=None) -> int:
         """
         Tries to mount a file with the given guid
         returns: `int` the number of files successfully mounted
@@ -169,7 +169,7 @@ class AbstractVfsFileProvider(ABC):
     def load_virtual_paths(self) -> int:
         import re
         import json
-        pattern = re.compile(f"^/{self.GameName}/Plugins/.+.upluginmanifest$", re.IGNORECASE)
+        pattern = re.compile(f"^{self.GameName}/Plugins/.+.upluginmanifest$", re.IGNORECASE)
 
         count = 0
         for _, v in self.files:
@@ -196,7 +196,7 @@ class AbstractVfsFileProvider(ABC):
     def load_localization(self, language_code = "en") -> int:
         #  https://github.com/FabianFG/CUE4Parse/blob/22ad6c42a27071cd91fdad71f2a02e8597031de9/CUE4Parse/FileProvider/AbstractFileProvider.cs#L63
         import re
-        pattern = re.compile( f"^/{self.GameName}/.+/{language_code}/.+.locres$", re.IGNORECASE)
+        pattern = re.compile( f"^{self.GameName}/.+/{language_code}/.+.locres$", re.IGNORECASE)
         self.LocalizedResources = {}
         count = 0
         for _, v in self.files:


### PR DESCRIPTION
- several typos
-  Fix an Issue with Paths, now same as: 
[https://github.com/FabianFG/CUE4Parse/blob/22ad6c42a27071cd91fdad71f2a02e8597031de9/CUE4Parse/FileProvider/AbstractFileProvider.cs#L63](url)